### PR TITLE
Update cljam to 0.7.1

### DIFF
--- a/cljam.rb
+++ b/cljam.rb
@@ -1,8 +1,8 @@
 class Cljam < Formula
   desc "Tools for manipulating DNA Sequence Alignment/Map (SAM)"
   homepage "https://chrovis.github.io/cljam/"
-  url "https://github.com/chrovis/cljam/releases/download/0.7.0/cljam", :using => :nounzip
-  sha256 "b4b1c3ddd0c803f3805d1c6efce2927e4927efc6e84e09d0bf955eca2500d990"
+  url "https://github.com/chrovis/cljam/releases/download/0.7.1/cljam", :using => :nounzip
+  sha256 "ad392806f41df11d94c046e8ae2ef277fca607f17ec60886286660436075755a"
 
   depends_on :java
 


### PR DESCRIPTION
This PR updates `cljam` executable to `0.7.1`

In [`chrovis/cljam`](https://github.com/chrovis/cljam), I've already done the following tasks
- [x] [Update the change log](https://github.com/chrovis/cljam/compare/99e17b7...7bef76a)
- [x] [Update dependencies](https://github.com/chrovis/cljam/compare/7bef76a...bda3f51)
- [x] [Update version `0.7.1-SNAPSHOT` -> `0.7.1`](https://github.com/chrovis/cljam/commit/2ad0e6dff07d807d91c4e16490ade198cfe5a2ed)
- [x] [Tag `0.7.1`](https://github.com/chrovis/cljam/tree/0.7.1)
- [x] [Release `0.7.1`](https://github.com/chrovis/cljam/releases/tag/0.7.1)
- [x] [Update `gh-pages`](https://github.com/chrovis/cljam/commit/1ff8f07528645a749151a463a85502212565c781)
- [x] [Deploy to clojars](https://clojars.org/cljam/versions/0.7.1)

Thank you 😃 