### PR TITLE
cljam 0.7.2

### DIFF
--- a/cljam.rb
+++ b/cljam.rb
@@ -1,8 +1,8 @@
 class Cljam < Formula
   desc "Tools for manipulating DNA Sequence Alignment/Map (SAM)"
   homepage "https://chrovis.github.io/cljam/"
-  url "https://github.com/chrovis/cljam/releases/download/0.7.1/cljam", :using => :nounzip
-  sha256 "ad392806f41df11d94c046e8ae2ef277fca607f17ec60886286660436075755a"
+  url "https://github.com/chrovis/cljam/releases/download/0.7.2/cljam", :using => :nounzip
+  sha256 "c8a8db50e446c5ee5b385d2322c1e875705aa0068a81e8c3ad0bc9a627478998"
 
   depends_on :java
 


### PR DESCRIPTION
This PR updates the `cljam` executable to `0.7.2`

- [x] [Update the change log](https://github.com/chrovis/cljam/commit/e068e34a44e381ff259f984124154cd8a3a19cf1#diff-4ac32a78649ca5bdd8e0ba38b7006a1e)
- [x] [Update dependencies](https://github.com/chrovis/cljam/compare/e068e34...4995151)
- [x] [Update version `0.7.2-SNAPSHOT` -> `0.7.2`](https://github.com/chrovis/cljam/commit/15199b7bf366dbaa3046f355eb57b10a2ecfe1aa)
- [x] [Tag `0.7.2`](https://github.com/chrovis/cljam/tree/0.7.2)
- [x] [Release `0.7.2`](https://github.com/chrovis/cljam/releases/tag/0.7.2)
- [x] [Update `gh-pages`](https://github.com/chrovis/cljam/commit/614466837b4ac2db57ba4b602b172c4611d625af)
- [x] [Deploy to clojars](https://clojars.org/cljam/versions/0.7.2)
- [x] Update Wiki [#1](https://github.com/chrovis/cljam/wiki/Getting-Started-for-Clojure-Beginners/e904066517bbf29ff7069e57ac06ce395c31702d), [#2](https://github.com/chrovis/cljam/wiki/Command-line-tool/bb3f969c066bf4ab2a66ee75ef1c57c413c84c16)