### PR TITLE
cljam 0.7.4

### DIFF
--- a/cljam.rb
+++ b/cljam.rb
@@ -1,8 +1,8 @@
 class Cljam < Formula
   desc "Tools for manipulating DNA Sequence Alignment/Map (SAM)"
   homepage "https://chrovis.github.io/cljam/"
-  url "https://github.com/chrovis/cljam/releases/download/0.7.3/cljam", :using => :nounzip
-  sha256 "299ec0907c7099661b952a242df4567d399b4827a231f21d3fec309e393fe30b"
+  url "https://github.com/chrovis/cljam/releases/download/0.7.4/cljam", :using => :nounzip
+  sha256 "b1b8a78e48bae6dc8f509f03669ac465ea610def98a5a4adc6e9c93457d02ffc"
 
   depends_on :java
 


### PR DESCRIPTION
This PR updates the `cljam` executable to `0.7.4`

- [x] [Update the change log](https://github.com/chrovis/cljam/commit/802bc6d824e06c8ee862a9d8de475f6da8edc3e0)
- [x] [Update version `0.7.4-SNAPSHOT` -> `0.7.4`](https://github.com/chrovis/cljam/commit/8b8050191167c86ec775a0cd9b6bd0cbf69fbb99)
- [x] [Tag `0.7.4`](https://github.com/chrovis/cljam/tree/0.7.4)
- [x] [Release `0.7.4`](https://github.com/chrovis/cljam/releases/tag/0.7.4)
- [x] [Update `gh-pages`](https://github.com/chrovis/cljam/commit/b01db8a022012ce0111afa732053beed3185762c)
- [x] [Deploy to clojars](https://clojars.org/cljam/versions/0.7.4)
- [x] Update Wiki [#1](https://github.com/chrovis/cljam/wiki/Command-line-tool/_compare/067ca5dc96719f59b88349c6844a2642373414a4...a847c5bc25bc993403aa8b7ed60d57c6ad41634d), [#2](https://github.com/chrovis/cljam/wiki/Getting-Started-for-Clojure-Beginners/_compare/11a4e1725b8749610e9c4e1ad36c0672b7c8d9ae...3ab74e12c5db59fd6f5bf145b6a292163cc95025)