### PR TITLE
cljam 0.8.0

### DIFF
--- a/cljam.rb
+++ b/cljam.rb
@@ -1,8 +1,8 @@
 class Cljam < Formula
   desc "Tools for manipulating DNA Sequence Alignment/Map (SAM)"
   homepage "https://chrovis.github.io/cljam/"
-  url "https://github.com/chrovis/cljam/releases/download/0.7.4/cljam", :using => :nounzip
-  sha256 "b1b8a78e48bae6dc8f509f03669ac465ea610def98a5a4adc6e9c93457d02ffc"
+  url "https://github.com/chrovis/cljam/releases/download/0.8.0/cljam", :using => :nounzip
+  sha256 "1090a80b24da12ddff1e003f0eae01c92bcddb38215d66618332ac19d36acf9f"
 
   depends_on :java
 


### PR DESCRIPTION
This PR updates the `cljam` executable to `0.8.0`

- [x] [Update the change log](https://github.com/chrovis/cljam/commit/1d414a33165baa3b905bdcf2cce9c99d77965ef1)
- [x] [Update version `0.7.5-SNAPSHOT` -> `0.8.0`](https://github.com/chrovis/cljam/commit/81734f9d2eac77373d9989dc32110ca2f2861ce2)
- [x] [Tag `0.8.0`](https://github.com/chrovis/cljam/tree/0.8.0)
- [x] [Release `0.8.0`](https://github.com/chrovis/cljam/releases/tag/0.8.0)
- [x] [Update `gh-pages`](https://github.com/chrovis/cljam/commit/53fc95d53e856b4a82606574c4b547a89d1d9fd1)
- [x] [Deploy to clojars](https://clojars.org/cljam/versions/0.8.0)
- [x] Update Wiki [#1](https://github.com/chrovis/cljam/wiki/Getting-Started-for-Clojure-Beginners/_compare/b80e479f830d2e0872b301a15779e1c16d0c07e9...d9018eee60c87c1a2858cf44b46ab2722f9f4d92), [#2](https://github.com/chrovis/cljam/wiki/Command-line-tool/_compare/a847c5bc25bc993403aa8b7ed60d57c6ad41634d...b6ed75a6de1d53b39bac6f682c735a267eafa3fd)