### PR TITLE
Update cljam to 0.8.3

### DIFF
--- a/cljam.rb
+++ b/cljam.rb
@@ -4,7 +4,7 @@ class Cljam < Formula
   url "https://github.com/chrovis/cljam/releases/download/0.8.3/cljam", :using => :nounzip
   sha256 "7bedabc234106cac532a52fe8fee722049312e17a7b62e6248b156eacc6d4712"
 
-  depends_on :java
+  depends_on "openjdk"
 
   def install
     chmod 0755, "cljam"

--- a/cljam.rb
+++ b/cljam.rb
@@ -1,8 +1,8 @@
 class Cljam < Formula
   desc "Tools for manipulating DNA Sequence Alignment/Map (SAM)"
   homepage "https://chrovis.github.io/cljam/"
-  url "https://github.com/chrovis/cljam/releases/download/0.8.0/cljam", :using => :nounzip
-  sha256 "1090a80b24da12ddff1e003f0eae01c92bcddb38215d66618332ac19d36acf9f"
+  url "https://github.com/chrovis/cljam/releases/download/0.8.3/cljam", :using => :nounzip
+  sha256 "7bedabc234106cac532a52fe8fee722049312e17a7b62e6248b156eacc6d4712"
 
   depends_on :java
 


### PR DESCRIPTION
This PR updates the `cljam` executable to `0.8.3` which includes updating the log4j2 dependency.
As far as I know, no known vulnerabilities affect previous versions of `cljam`.
I'm very sorry, I forgot to submit PRs here for `0.8.1` and `0.8.2`.

- [x] [Update the changelog](https://github.com/chrovis/cljam/commit/7c7941742bc8f0f907df004195345967647714fc)
- [x] [Update version `0.8.3-SNAPSHOT` -> `0.8.3`](https://github.com/chrovis/cljam/commit/f7f9b02da6bd6662615e47d850b459cf38fa9686)
- [x] [Tag `0.8.3`](https://github.com/chrovis/cljam/tree/0.8.3)
- [x] [Release `0.8.3`](https://github.com/chrovis/cljam/releases/tag/0.8.3)
- [x] [Update `gh-pages`](https://github.com/chrovis/cljam/commit/37f517f5dcff70eb6b4edfa6bb0e4fa50a5dcffd)
- [x] [Deploy to clojars](https://clojars.org/cljam/versions/0.8.3)
- [x] Update Wiki [#1](https://github.com/chrovis/cljam/wiki/Getting-Started-for-Clojure-Beginners/0a799dd75aace257a1d700114c2584063b8674c0), [#2](https://github.com/chrovis/cljam/wiki/Command-line-tool/c16ccb0d54ba4bbf6edb11563049f44dbe88a594)