### PR TITLE
Update cljam to 0.8.4

### DIFF
--- a/cljam.rb
+++ b/cljam.rb
@@ -1,8 +1,8 @@
 class Cljam < Formula
   desc "Tools for manipulating DNA Sequence Alignment/Map (SAM)"
   homepage "https://chrovis.github.io/cljam/"
-  url "https://github.com/chrovis/cljam/releases/download/0.8.3/cljam", :using => :nounzip
-  sha256 "7bedabc234106cac532a52fe8fee722049312e17a7b62e6248b156eacc6d4712"
+  url "https://github.com/chrovis/cljam/releases/download/0.8.4/cljam", :using => :nounzip
+  sha256 "9d18a7f5d2fa4e93aa54c0b6663739ca142cee86d2992b3e792bc55a062b9a52"
 
   depends_on "openjdk"
 


### PR DESCRIPTION
This PR updates the `cljam` executable to the latest release `0.8.4`

- [x] [Update the changelog](https://github.com/chrovis/cljam/commit/f5d7c0614cb2f34390186e5603220968594671f8)
- [x] [Update version `0.8.4-SNAPSHOT` -> `0.8.4`](https://github.com/chrovis/cljam/commit/6fbc2ec633ed0d8ab4d503f030c441927f8502cf)
- [x] [Tag `0.8.4`](https://github.com/chrovis/cljam/tree/0.8.4)
- [x] [Release `0.8.4`](https://github.com/chrovis/cljam/releases/tag/0.8.4)
- [x] [Update `gh-pages`](https://github.com/chrovis/cljam/commit/a34d4df7bd8a8e12ad07ba34c32806c3df51db5c)
- [x] [Deploy to clojars](https://clojars.org/cljam/versions/0.8.4)
- [x] Update Wiki [#1](https://github.com/chrovis/cljam/wiki/Getting-Started-for-Clojure-Beginners/_compare/476528302436b250a5c55d808dc2dc1eb121eba9), [#2](https://github.com/chrovis/cljam/wiki/Command-line-tool/_compare/c37b75e643baa79df506a9d894b16b8d735b3683)