### PR TITLE
Add papery formula

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,4 +8,12 @@ Xcoo's formulae for the [Homebrew][homebrew] package manager.
 
 or `brew tap xcoo/formulae` and then `brew install <formula>`.
 
+## Supported Formulae
+
+- [`cljam`](cljam.rb)
+- [`gnife`](gnife.rb)
+- [`kyoto-cabinet-java`](kyoto-cabinet-java.rb)
+- [`libbwa`](libbwa.rb)
+- [`papery`](papery.rb)
+
 [homebrew]: http://brew.sh/

--- a/papery.rb
+++ b/papery.rb
@@ -1,0 +1,115 @@
+class Papery < Formula
+  include Language::Python::Virtualenv
+
+  desc "papery is  is a simple, static site generator written in Python - supports Markdown/JSON input and Jinja2 templating."
+  homepage "https://github.com/withletters/papery"
+  url "https://files.pythonhosted.org/packages/ce/f7/d543816821229a14587984f1a6431589b4d52f994effc2427643b0f087fd/papery-0.7.2.tar.gz"
+  sha256 "ca4756efd314535cd69dcfd5d302c2cf502df7609154452007a6903451c66da7"
+  license "Apache-2.0"
+
+  depends_on "libyaml"
+  depends_on "markdownlint-cli" => :optional
+  depends_on "python@3.12"
+
+  resource "docopt" do
+    url "https://files.pythonhosted.org/packages/a2/55/8f8cab2afd404cf578136ef2cc5dfb50baa1761b68c9da1fb1e4eed343c9/docopt-0.6.2.tar.gz"
+    sha256 "49b3a825280bd66b3aa83585ef59c4a8c82f2c8a522dbe754a8bc8d08c85c491"
+  end
+
+  resource "importlib-metadata" do
+    url "https://files.pythonhosted.org/packages/a0/fc/c4e6078d21fc4fa56300a241b87eae76766aa380a23fc450fc85bb7bf547/importlib_metadata-7.1.0.tar.gz"
+    sha256 "b78938b926ee8d5f020fc4772d487045805a55ddbad2ecf21c6d60938dc7fcd2"
+  end
+
+  resource "jinja2" do
+    url "https://files.pythonhosted.org/packages/b2/5e/3a21abf3cd467d7876045335e681d276ac32492febe6d98ad89562d1a7e1/Jinja2-3.1.3.tar.gz"
+    sha256 "ac8bd6544d4bb2c9792bf3a159e80bba8fda7f07e81bc3aed565432d5925ba90"
+  end
+
+  resource "jsonlint" do
+    url "https://files.pythonhosted.org/packages/5e/6b/a04e8ae41422fc70b3cfc52e886c73af5efd7330a85a99b9aa2afac37540/jsonlint-0.1.tar.gz"
+    sha256 "0728ea2827f274ff96a1484b3f5ec5ef7b0954bf7b875ba4a842d8ddf5c74860"
+  end
+
+  resource "markdown" do
+    url "https://files.pythonhosted.org/packages/22/02/4785861427848cc11e452cc62bb541006a1087cf04a1de83aedd5530b948/Markdown-3.6.tar.gz"
+    sha256 "ed4f41f6daecbeeb96e576ce414c41d2d876daa9a16cb35fa8ed8c2ddfad0224"
+  end
+
+  resource "markupsafe" do
+    url "https://files.pythonhosted.org/packages/87/5b/aae44c6655f3801e81aa3eef09dbbf012431987ba564d7231722f68df02d/MarkupSafe-2.1.5.tar.gz"
+    sha256 "d283d37a890ba4c1ae73ffadf8046435c76e7bc2247bbb63c00bd1a709c6544b"
+  end
+
+  resource "pathspec" do
+    url "https://files.pythonhosted.org/packages/ca/bc/f35b8446f4531a7cb215605d100cd88b7ac6f44ab3fc94870c120ab3adbf/pathspec-0.12.1.tar.gz"
+    sha256 "a482d51503a1ab33b1c67a6c3813a26953dbdc71c31dacaef9a838c4e29f5712"
+  end
+
+  resource "pykwalify" do
+    url "https://files.pythonhosted.org/packages/d5/77/2d6849510dbfce5f74f1f69768763630ad0385ad7bb0a4f39b55de3920c7/pykwalify-1.8.0.tar.gz"
+    sha256 "796b2ad3ed4cb99b88308b533fb2f559c30fa6efb4fa9fda11347f483d245884"
+  end
+
+  resource "pymdown-extensions" do
+    url "https://files.pythonhosted.org/packages/b0/ec/e3d966cfb286d5a48e7c43a559a297b857ab935209ee9072e5a5492706c9/pymdown_extensions-10.7.1.tar.gz"
+    sha256 "c70e146bdd83c744ffc766b4671999796aba18842b268510a329f7f64700d584"
+  end
+
+  resource "python-dateutil" do
+    url "https://files.pythonhosted.org/packages/66/c0/0c8b6ad9f17a802ee498c46e004a0eb49bc148f2fd230864601a86dcf6db/python-dateutil-2.9.0.post0.tar.gz"
+    sha256 "37dd54208da7e1cd875388217d5e00ebd4179249f90fb72437e91a35459a0ad3"
+  end
+
+  resource "pyyaml" do
+    url "https://files.pythonhosted.org/packages/cd/e5/af35f7ea75cf72f2cd079c95ee16797de7cd71f29ea7c68ae5ce7be1eda0/PyYAML-6.0.1.tar.gz"
+    sha256 "bfdf460b1736c775f2ba9f6a92bca30bc2095067b8a9d77876d1fad6cc3b4a43"
+  end
+
+  resource "ruamel-yaml" do
+    url "https://files.pythonhosted.org/packages/29/81/4dfc17eb6ebb1aac314a3eb863c1325b907863a1b8b1382cdffcb6ac0ed9/ruamel.yaml-0.18.6.tar.gz"
+    sha256 "8b27e6a217e786c6fbe5634d8f3f11bc63e0f80f6a5890f28863d9c45aac311b"
+  end
+
+  resource "ruamel-yaml-clib" do
+    url "https://files.pythonhosted.org/packages/46/ab/bab9eb1566cd16f060b54055dd39cf6a34bfa0240c53a7218c43e974295b/ruamel.yaml.clib-0.2.8.tar.gz"
+    sha256 "beb2e0404003de9a4cab9753a8805a8fe9320ee6673136ed7f04255fe60bb512"
+  end
+
+  resource "setuptools" do
+    url "https://files.pythonhosted.org/packages/d6/4f/b10f707e14ef7de524fe1f8988a294fb262a29c9b5b12275c7e188864aed/setuptools-69.5.1.tar.gz"
+    sha256 "6c1fccdac05a97e598fb0ae3bbed5904ccb317337a51139dcd51453611bbb987"
+  end
+
+  resource "six" do
+    url "https://files.pythonhosted.org/packages/71/39/171f1c67cd00715f190ba0b100d606d440a28c93c7714febeca8b79af85e/six-1.16.0.tar.gz"
+    sha256 "1e61c37477a1626458e36f7b1d82aa5c9b094fa4802892072e49de9c60c4c926"
+  end
+
+  resource "typing-extensions" do
+    url "https://files.pythonhosted.org/packages/f6/f3/b827b3ab53b4e3d8513914586dcca61c355fa2ce8252dea4da56e67bf8f2/typing_extensions-4.11.0.tar.gz"
+    sha256 "83f085bd5ca59c80295fc2a82ab5dac679cbe02b9f33f7d83af68e241bea51b0"
+  end
+
+  resource "yamllint" do
+    url "https://files.pythonhosted.org/packages/da/06/d8cee5c3dfd550cc0a466ead8b321138198485d1034130ac1393cc49d63e/yamllint-1.35.1.tar.gz"
+    sha256 "7a003809f88324fd2c877734f2d575ee7881dd9043360657cc8049c809eba6cd"
+  end
+
+  resource "zipp" do
+    url "https://files.pythonhosted.org/packages/3e/ef/65da662da6f9991e87f058bc90b91a935ae655a16ae5514660d6460d1298/zipp-3.18.1.tar.gz"
+    sha256 "2884ed22e7d8961de1c9a05142eb69a247f120291bc0206a00a7642f09b5b715"
+  end
+
+  def install
+    # Work around ruamel.yaml.clib not building on Xcode 15.3, remove after a new release
+    # has resolved: https://sourceforge.net/p/ruamel-yaml-clib/tickets/32/
+    ENV.append_to_cflags "-Wno-incompatible-function-pointer-types" if DevelopmentTools.clang_build_version >= 1500
+
+    virtualenv_install_with_resources
+  end
+
+  test do
+    system bin/"papery", "--version"
+  end
+end


### PR DESCRIPTION
I newly added [papery](https://github.com/withletters/papery) formula.

I conformed to [Python for Formula Authors](https://docs.brew.sh/Python-for-Formula-Authors) and referred to formulae of Python tools like [`yamllint.rb`](https://github.com/Homebrew/homebrew-core/blob/master/Formula/y/yamllint.rb) and [`ansible-lint.rb`](https://github.com/Homebrew/homebrew-core/blob/master/Formula/a/ansible-lint.rb).

Installation can be confirmed by the following command:

```console
$ brew install papery.rb
==> Fetching papery
==> Downloading 
 ...
🍺  /opt/homebrew/Cellar/papery/0.7.2: 715 files, 8MB, built in 1 minute 23 seconds
$ papery --version
0.7.2
```