### PR TITLE
Update cljam to 0.8.5

### DIFF
--- a/cljam.rb
+++ b/cljam.rb
@@ -1,8 +1,8 @@
 class Cljam < Formula
   desc "Tools for manipulating DNA Sequence Alignment/Map (SAM)"
   homepage "https://chrovis.github.io/cljam/"
-  url "https://github.com/chrovis/cljam/releases/download/0.8.4/cljam", :using => :nounzip
-  sha256 "9d18a7f5d2fa4e93aa54c0b6663739ca142cee86d2992b3e792bc55a062b9a52"
+  url "https://github.com/chrovis/cljam/releases/download/0.8.5/cljam", :using => :nounzip
+  sha256 "574f65cefa32713e4f2089292d1ed43480df0d1556275e5d0e0d4e971cb6898b"
 
   depends_on "openjdk"
 


### PR DESCRIPTION
This PR updates cljam to `0.8.5`.
Since [gnife](https://github.com/chrovis/gnife) has already taken over all the functions of `cljam`, this will be the final release of the standalone `cljam` executable.
This version includes a bugfix (https://github.com/chrovis/cljam/issues/295) and some performance improvements.

- [x] [Update the changelog](https://github.com/chrovis/cljam/commit/6488a34f0278237eda1ebb13c3bd7da15e24eecd)
- [x] [Update version `0.8.5-SNAPSHOT` -> `0.8.5`](https://github.com/chrovis/cljam/commit/95d006ce98214b5eefca52850cbdbc6485f6f986)
- [x] [Tag `0.8.5`](https://github.com/chrovis/cljam/tree/0.8.5)
- [x] [Release `0.8.5`](https://github.com/chrovis/cljam/releases/tag/0.8.5)
- [x] [Update `gh-pages`](https://github.com/chrovis/cljam/commit/4aa8e42920bcbf380bc6e4c6294c1efc80933c72)
- [x] [Deploy to clojars](https://clojars.org/cljam/versions/0.8.5)
- [x] Update Wiki [#1](https://github.com/chrovis/cljam/wiki/Getting-Started-for-Clojure-Beginners/_compare/476528302436b250a5c55d808dc2dc1eb121eba9...234eac20955794f51d6aea5a720318e688b8dd8d), [#2](https://github.com/chrovis/cljam/wiki/Command-line-tool/_compare/c37b75e643baa79df506a9d894b16b8d735b3683...d6f4a92225a2d01763b527333fd934f42c8e98e9)